### PR TITLE
fix(user-data2): install doesn't install all required apps

### DIFF
--- a/cloud-init/user-data2
+++ b/cloud-init/user-data2
@@ -94,12 +94,14 @@ packages:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - gnupg2
   - iotop
   - jq
   - keyutils
   - lsb-release
   - mlocate
   - net-tools
+  - nfs-kernel-server
   - nfs-common
   - ntpdate
   - python3


### PR DESCRIPTION
I think adding these two packages like in `user-data` let the full install complete. Docker wasn't properly installed and I think it's the `gnupg2` package that was missing.